### PR TITLE
Bump require-dir to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-zip": "^3.1.0",
     "jspm": "^0.16.20",
     "node-lambda": "^0.7.1",
-    "require-dir": "^0.2.0",
+    "require-dir": "^0.3.2",
     "run-sequence": "^1.1.0",
     "systemjs": "^0.19.0",
     "systemjs-builder": "^0.15.7"


### PR DESCRIPTION
Hi!

Node v8 introduced some breaking changes that break versions of `require-dir` prior to `0.3.2`. On my local dev machine, which runs Node 8, a clean clone and `npm install` of this repo pulled down an older version of `request-dir` that crashed on run.

This just bumps the package.json. The more proper solution would be to introduce a lockfile of some sort (whether a `yarnfile.lock` or `package-lock.json`), but seeing as this isn't my project I don't want to pick a side on yarn / vs npm for you :P.