### PR TITLE
Region fix

### DIFF
--- a/gulp-tasks/_upload.js
+++ b/gulp-tasks/_upload.js
@@ -9,7 +9,8 @@ gulp.task('upload', ['generate'], function ( cb ) {
   var config = JSON.parse(fs.readFileSync('./src/skill/models/config.json','utf8'))
 
   var opts = {
-    profile: config.awsProfileName
+    profile: config.awsProfileName,
+    region: config.dynamoRegion
   }
 
   return gulp.src('./src/skill/**/*.{js,json}', { base: "." })


### PR DESCRIPTION
Upload throws an error if lambda function is in different region than us-east-1. Passing region from config.js fixes issue.